### PR TITLE
NB-A2-05: Salesgraph implemented

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "react-dom": "19.0.0",
         "react-error-boundary": "^6.0.0",
         "react-router-dom": "^7.7.1",
+        "recharts": "^3.1.2",
         "yarn": "^1.22.22"
     },
     "devDependencies": {

--- a/src/components/SalesGraph/SalesGraph.constants.ts
+++ b/src/components/SalesGraph/SalesGraph.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Domain for Y-axis
+ */
+export const DOMAIN = [0, 240];
+
+/**
+ * Y-axis ticks
+ */
+export const Y_TICKS = [0, 40, 80, 120, 160, 200, 240];

--- a/src/components/SalesGraph/SalesGraph.style.ts
+++ b/src/components/SalesGraph/SalesGraph.style.ts
@@ -10,8 +10,6 @@ export const SalesGraphContainer = styled(Box)(({ theme }) => {
     } = theme;
 
     return {
-        boxShadow:
-            '0px 1px 3px rgba(0, 0, 0, 0.10), 0px 1px 2px rgba(0, 0, 0, 0.06)',
         padding: spacing(6),
         borderRadius: pxToRem(12),
         outline: 'none',

--- a/src/components/SalesGraph/SalesGraph.style.ts
+++ b/src/components/SalesGraph/SalesGraph.style.ts
@@ -1,0 +1,83 @@
+import { CartesianGrid, XAxis, YAxis } from 'recharts';
+
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const SalesGraphContainer = styled(Box)(({ theme }) => {
+    const {
+        spacing,
+        typography: { pxToRem },
+    } = theme;
+
+    return {
+        boxShadow:
+            '0px 1px 3px rgba(0, 0, 0, 0.10), 0px 1px 2px rgba(0, 0, 0, 0.06)',
+        padding: spacing(6),
+        borderRadius: pxToRem(12),
+        outline: 'none',
+        userSelect: 'none',
+        marginTop: pxToRem(20),
+
+        '& *': {
+            outline: 'none',
+        },
+    };
+});
+
+export const StyledCartesianGrid = styled(CartesianGrid)(({ theme }) => {
+    const { palette } = theme;
+    return {
+        stroke: palette.grey[300],
+        strokeWidth: 0.5,
+    };
+});
+
+export const StyledXAxis = styled(XAxis)(({ theme }) => {
+    const {
+        typography: { subtitle2 },
+        palette,
+    } = theme;
+
+    return {
+        '& .recharts-cartesian-axis-tick-value': {
+            ...subtitle2,
+            fill: palette.grey[500],
+        },
+    };
+});
+
+export const StyledYAxis = styled(YAxis)(({ theme }) => {
+    const {
+        typography: { subtitle2 },
+        palette,
+    } = theme;
+
+    return {
+        '& .recharts-cartesian-axis-tick-value': {
+            ...subtitle2,
+            fill: palette.grey[500],
+        },
+    };
+});
+
+export const SalesInfo = styled(Box)(({ theme }) => {
+    const {
+        typography: { pxToRem },
+        mixins,
+        palette: { grey },
+    } = theme;
+
+    return {
+        ...mixins.flex('flex-start'),
+        padding: `${pxToRem(10)} 0`,
+        margin: `${pxToRem(20)} 0`,
+        gap: pxToRem(8),
+        fontSize: pxToRem(20),
+        color: grey[900],
+
+        [theme.breakpoints.down('sm')]: {
+            padding: 0,
+            margin: 0,
+        },
+    };
+});

--- a/src/components/SalesGraph/SalesGraph.style.ts
+++ b/src/components/SalesGraph/SalesGraph.style.ts
@@ -72,6 +72,7 @@ export const SalesInfo = styled(Box)(({ theme }) => {
         padding: `${pxToRem(10)} 0`,
         margin: `${pxToRem(20)} 0`,
         gap: pxToRem(8),
+        fontWeight: 700,
         fontSize: pxToRem(20),
         color: grey[900],
 

--- a/src/components/SalesGraph/SalesGraph.tsx
+++ b/src/components/SalesGraph/SalesGraph.tsx
@@ -26,7 +26,7 @@ export const SalesGraph = () => {
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
     return (
-        <SalesGraphContainer>
+        <SalesGraphContainer sx={{ boxShadow: 1 }}>
             <SalesInfo>
                 Sales
                 <Tooltip title="More info" arrow>

--- a/src/components/SalesGraph/SalesGraph.tsx
+++ b/src/components/SalesGraph/SalesGraph.tsx
@@ -56,6 +56,12 @@ export const SalesGraph = () => {
                         axisLine={false}
                         tickMargin={isSmallScreen ? 30 : 20}
                         angle={isSmallScreen ? -45 : 0}
+                        tickFormatter={(value: string) =>
+                            new Date(value).toLocaleDateString('en-US', {
+                                day: '2-digit',
+                                month: 'short',
+                            })
+                        }
                     />
 
                     <StyledYAxis

--- a/src/components/SalesGraph/SalesGraph.tsx
+++ b/src/components/SalesGraph/SalesGraph.tsx
@@ -1,0 +1,92 @@
+import { salesGraphData } from 'data/SalesGraph/SalesGraph';
+import {
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    Tooltip as SalesLineToolTip,
+} from 'recharts';
+
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { useMediaQuery } from '@mui/material';
+import Tooltip from '@mui/material/Tooltip';
+
+import { SALESGRAPH_HEIGHT } from '@constant/common.constant';
+import { theme } from '@theme/index';
+
+import {
+    SalesGraphContainer,
+    SalesInfo,
+    StyledCartesianGrid,
+    StyledXAxis,
+    StyledYAxis,
+} from './SalesGraph.style';
+import { SalesGraphTooltip } from './SalesGraphTooltip';
+
+export const SalesGraph = () => {
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+    return (
+        <SalesGraphContainer>
+            <SalesInfo>
+                Sales
+                <Tooltip title="More info" arrow>
+                    <InfoOutlinedIcon
+                        fontSize="small"
+                        sx={{
+                            color: theme.palette.grey[500],
+                        }}
+                    />
+                </Tooltip>
+            </SalesInfo>
+
+            <ResponsiveContainer width="100%" height={SALESGRAPH_HEIGHT}>
+                <LineChart
+                    data={salesGraphData}
+                    margin={{
+                        top: 20,
+                        left: isSmallScreen ? -20 : 40,
+                        bottom: isSmallScreen ? 40 : 10,
+                    }}
+                >
+                    <StyledCartesianGrid vertical={false} />
+
+                    <StyledXAxis
+                        dataKey="date"
+                        tickLine={false}
+                        axisLine={false}
+                        tickMargin={isSmallScreen ? 30 : 20}
+                        angle={isSmallScreen ? -45 : 0}
+                    />
+
+                    <StyledYAxis
+                        ticks={[0, 40, 80, 120, 160, 200, 240]}
+                        tickFormatter={(value) => `${value}K`}
+                        domain={[0, 240]}
+                        tickLine={false}
+                        axisLine={false}
+                        tickMargin={isSmallScreen ? 0 : 50}
+                        tick={isSmallScreen ? false : undefined}
+                    />
+
+                    <SalesLineToolTip
+                        cursor={{
+                            stroke: '#E5E7EB',
+                            strokeWidth: 2,
+                            strokeDasharray: '6 2',
+                        }}
+                        content={<SalesGraphTooltip />}
+                    />
+
+                    <Line
+                        type="monotone"
+                        dataKey="amount"
+                        stroke="#00C49F"
+                        strokeWidth={2}
+                        dot={false}
+                        activeDot={{ r: 4 }}
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </SalesGraphContainer>
+    );
+};

--- a/src/components/SalesGraph/SalesGraph.tsx
+++ b/src/components/SalesGraph/SalesGraph.tsx
@@ -7,8 +7,7 @@ import {
 } from 'recharts';
 
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { useMediaQuery } from '@mui/material';
-import Tooltip from '@mui/material/Tooltip';
+import { Tooltip, useMediaQuery } from '@mui/material';
 
 import { SALESGRAPH_HEIGHT } from '@constant/common.constant';
 import { theme } from '@theme/index';

--- a/src/components/SalesGraph/SalesGraph.tsx
+++ b/src/components/SalesGraph/SalesGraph.tsx
@@ -1,4 +1,4 @@
-import { salesGraphData } from 'data/SalesGraph/SalesGraph';
+import { SalesGraphData } from 'data/SalesGraph/SalesGraph.type';
 import {
     Line,
     LineChart,
@@ -13,6 +13,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { SALESGRAPH_HEIGHT } from '@constant/common.constant';
 import { theme } from '@theme/index';
 
+import { DOMAIN, Y_TICKS } from './SalesGraph.constants';
 import {
     SalesGraphContainer,
     SalesInfo,
@@ -22,7 +23,7 @@ import {
 } from './SalesGraph.style';
 import { SalesGraphTooltip } from './SalesGraphTooltip';
 
-export const SalesGraph = () => {
+export const SalesGraph = ({ data }: { data: SalesGraphData[] }) => {
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
     return (
@@ -41,7 +42,7 @@ export const SalesGraph = () => {
 
             <ResponsiveContainer width="100%" height={SALESGRAPH_HEIGHT}>
                 <LineChart
-                    data={salesGraphData}
+                    data={data}
                     margin={{
                         top: 20,
                         left: isSmallScreen ? -20 : 40,
@@ -65,9 +66,9 @@ export const SalesGraph = () => {
                     />
 
                     <StyledYAxis
-                        ticks={[0, 40, 80, 120, 160, 200, 240]}
+                        ticks={Y_TICKS}
                         tickFormatter={(value) => `${value}K`}
-                        domain={[0, 240]}
+                        domain={DOMAIN}
                         tickLine={false}
                         axisLine={false}
                         tickMargin={isSmallScreen ? 0 : 50}
@@ -76,17 +77,17 @@ export const SalesGraph = () => {
 
                     <SalesLineToolTip
                         cursor={{
-                            stroke: '#E5E7EB',
+                            stroke: theme.palette.grey[200],
                             strokeWidth: 2,
                             strokeDasharray: '6 2',
                         }}
-                        content={<SalesGraphTooltip />}
+                        content={<SalesGraphTooltip label="string" />}
                     />
 
                     <Line
                         type="monotone"
                         dataKey="amount"
-                        stroke="#00C49F"
+                        stroke={theme.palette.primary.main}
                         strokeWidth={2}
                         dot={false}
                         activeDot={{ r: 4 }}

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -5,14 +5,16 @@ export const TooltipContainer = styled(Box)(({ theme }) => {
     const {
         palette,
         typography: { pxToRem },
+        shadows,
     } = theme;
 
     return {
-        borderRadius: 8,
+        borderRadius: pxToRem(8),
         backgroundColor: palette.common.white,
         padding: `${pxToRem(8)} ${pxToRem(18)}`,
         border: 'none',
         transform: 'translateX(-50%)',
+        boxShadow: shadows[1],
     };
 });
 

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -28,7 +28,7 @@ export const TooltipLabel = styled(Typography)(({ theme }) => {
     };
 });
 
-export const SalesDisplay = styled(Box)(({ theme }) => {
+export const SalesDataInfo = styled(Box)(({ theme }) => {
     const {
         typography: { pxToRem },
         mixins,
@@ -41,7 +41,7 @@ export const SalesDisplay = styled(Box)(({ theme }) => {
     };
 });
 
-export const SalesPoint = styled(Box)(({ theme }) => {
+export const Indicator = styled(Box)(({ theme }) => {
     const {
         palette,
         typography: { pxToRem },

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -28,7 +28,7 @@ export const TooltipLabel = styled(Typography)(({ theme }) => {
     };
 });
 
-export const SalesRow = styled(Box)(({ theme }) => {
+export const SalesDisplay = styled(Box)(({ theme }) => {
     const {
         typography: { pxToRem },
         mixins,
@@ -41,7 +41,7 @@ export const SalesRow = styled(Box)(({ theme }) => {
     };
 });
 
-export const SalesDot = styled(Box)(({ theme }) => {
+export const SalesPoint = styled(Box)(({ theme }) => {
     const {
         palette,
         typography: { pxToRem },

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -32,11 +32,11 @@ export const TooltipLabel = styled(Typography)(({ theme }) => {
 export const SalesRow = styled(Box)(({ theme }) => {
     const {
         typography: { pxToRem },
+        mixins,
     } = theme;
 
     return {
-        display: 'flex',
-        alignItems: 'center',
+        ...mixins.flex('center', 'center'),
         gap: pxToRem(4),
         marginBottom: pxToRem(8),
     };

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -12,7 +12,6 @@ export const TooltipContainer = styled(Box)(({ theme }) => {
         backgroundColor: palette.common.white,
         padding: `${pxToRem(8)} ${pxToRem(18)}`,
         border: 'none',
-        boxShadow: '0px 1px 3px rgba(0,0,0,0.10), 0px 1px 2px rgba(0,0,0,0.06)',
         transform: 'translateX(-50%)',
     };
 });

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.style.ts
@@ -1,0 +1,75 @@
+import { Box, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const TooltipContainer = styled(Box)(({ theme }) => {
+    const {
+        palette,
+        typography: { pxToRem },
+    } = theme;
+
+    return {
+        borderRadius: 8,
+        backgroundColor: palette.common.white,
+        padding: `${pxToRem(8)} ${pxToRem(18)}`,
+        border: 'none',
+        boxShadow: '0px 1px 3px rgba(0,0,0,0.10), 0px 1px 2px rgba(0,0,0,0.06)',
+        transform: 'translateX(-50%)',
+    };
+});
+
+export const TooltipLabel = styled(Typography)(({ theme }) => {
+    const {
+        palette,
+        typography: { pxToRem },
+    } = theme;
+
+    return {
+        color: palette.grey[600],
+        fontSize: pxToRem(12),
+    };
+});
+
+export const SalesRow = styled(Box)(({ theme }) => {
+    const {
+        typography: { pxToRem },
+    } = theme;
+
+    return {
+        display: 'flex',
+        alignItems: 'center',
+        gap: pxToRem(4),
+        marginBottom: pxToRem(8),
+    };
+});
+
+export const SalesDot = styled(Box)(({ theme }) => {
+    const {
+        palette,
+        typography: { pxToRem },
+    } = theme;
+
+    return {
+        width: pxToRem(8),
+        height: pxToRem(8),
+        borderRadius: '50%',
+        backgroundColor: palette.primary.main,
+    };
+});
+
+export const LabelPrefix = styled(Box)(({ theme }) => {
+    const { palette } = theme;
+
+    return {
+        color: palette.grey[500],
+        display: 'inline',
+    };
+});
+
+export const LabelValue = styled(Box)(({ theme }) => {
+    const { palette } = theme;
+
+    return {
+        color: palette.grey[900],
+        display: 'inline',
+    };
+});

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
@@ -1,0 +1,31 @@
+import { Typography } from '@mui/material';
+
+import {
+    LabelPrefix,
+    LabelValue,
+    SalesDot,
+    SalesRow,
+    TooltipContainer,
+    TooltipLabel,
+} from './SalesGraphTooltip.style';
+import { SalesGraphTooltipProps } from './SalesGraphTooltip.type';
+
+export const SalesGraphTooltip = ({
+    payload,
+    label,
+}: SalesGraphTooltipProps) => {
+    if (!payload || !payload.length) return null;
+
+    return (
+        <TooltipContainer>
+            <TooltipLabel variant="caption">{`${label}, 2021`}</TooltipLabel>
+            <SalesRow>
+                <SalesDot />
+                <Typography variant="body2">
+                    <LabelPrefix>Sales:</LabelPrefix>{' '}
+                    <LabelValue>${payload[0].value}k</LabelValue>
+                </Typography>
+            </SalesRow>
+        </TooltipContainer>
+    );
+};

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
@@ -17,7 +17,7 @@ export const SalesGraphTooltip = ({
     if (!payload || !payload.length) return null;
 
     return (
-        <TooltipContainer>
+        <TooltipContainer sx={{ boxShadow: 1 }}>
             <TooltipLabel variant="caption">{`${label}, 2021`}</TooltipLabel>
             <SalesRow>
                 <SalesDot />

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
@@ -1,10 +1,10 @@
 import { Typography } from '@mui/material';
 
 import {
+    Indicator,
     LabelPrefix,
     LabelValue,
-    SalesDisplay,
-    SalesPoint,
+    SalesDataInfo,
     TooltipContainer,
     TooltipLabel,
 } from './SalesGraphTooltip.style';
@@ -19,13 +19,13 @@ export const SalesGraphTooltip = ({
     return (
         <TooltipContainer sx={{ boxShadow: 1 }}>
             <TooltipLabel variant="caption">{label}</TooltipLabel>
-            <SalesDisplay>
-                <SalesPoint />
+            <SalesDataInfo>
+                <Indicator />
                 <Typography variant="body2">
                     <LabelPrefix>Sales:</LabelPrefix>{' '}
                     <LabelValue>${payload[0].value}k</LabelValue>
                 </Typography>
-            </SalesDisplay>
+            </SalesDataInfo>
         </TooltipContainer>
     );
 };

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
@@ -16,9 +16,15 @@ export const SalesGraphTooltip = ({
 }: SalesGraphTooltipProps) => {
     if (!payload || !payload.length) return null;
 
+    const formattedLabel = new Date(label).toLocaleDateString('en-US', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    });
+
     return (
-        <TooltipContainer sx={{ boxShadow: 1 }}>
-            <TooltipLabel variant="caption">{label}</TooltipLabel>
+        <TooltipContainer role="tooltip">
+            <TooltipLabel variant="caption">{formattedLabel}</TooltipLabel>
             <SalesDataInfo>
                 <Indicator />
                 <Typography variant="body2">

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.tsx
@@ -3,8 +3,8 @@ import { Typography } from '@mui/material';
 import {
     LabelPrefix,
     LabelValue,
-    SalesDot,
-    SalesRow,
+    SalesDisplay,
+    SalesPoint,
     TooltipContainer,
     TooltipLabel,
 } from './SalesGraphTooltip.style';
@@ -18,14 +18,14 @@ export const SalesGraphTooltip = ({
 
     return (
         <TooltipContainer sx={{ boxShadow: 1 }}>
-            <TooltipLabel variant="caption">{`${label}, 2021`}</TooltipLabel>
-            <SalesRow>
-                <SalesDot />
+            <TooltipLabel variant="caption">{label}</TooltipLabel>
+            <SalesDisplay>
+                <SalesPoint />
                 <Typography variant="body2">
                     <LabelPrefix>Sales:</LabelPrefix>{' '}
                     <LabelValue>${payload[0].value}k</LabelValue>
                 </Typography>
-            </SalesRow>
+            </SalesDisplay>
         </TooltipContainer>
     );
 };

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
@@ -3,5 +3,5 @@
  */
 export type SalesGraphTooltipProps = {
     payload?: { value: number }[];
-    label?: string | number;
+    label: string;
 };

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
@@ -1,0 +1,11 @@
+/**
+ * Props for the SalesGraph tooltip component.
+ *
+ * @typedef {Object} SalesGraphTooltipProps
+ * @property {{ value: number }[]=} payload - Array of payload objects, each containing a numeric value.
+ * @property {(string|number)=} label - Label displayed in the tooltip, can be a string or a number.
+ */
+export type SalesGraphTooltipProps = {
+    payload?: { value: number }[];
+    label?: string | number;
+};

--- a/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/SalesGraphTooltip.type.ts
@@ -1,9 +1,5 @@
 /**
  * Props for the SalesGraph tooltip component.
- *
- * @typedef {Object} SalesGraphTooltipProps
- * @property {{ value: number }[]=} payload - Array of payload objects, each containing a numeric value.
- * @property {(string|number)=} label - Label displayed in the tooltip, can be a string or a number.
  */
 export type SalesGraphTooltipProps = {
     payload?: { value: number }[];

--- a/src/components/SalesGraph/SalesGraphTooltip/index.ts
+++ b/src/components/SalesGraph/SalesGraphTooltip/index.ts
@@ -1,0 +1,1 @@
+export { SalesGraphTooltip } from './SalesGraphTooltip';

--- a/src/components/SalesGraph/index.ts
+++ b/src/components/SalesGraph/index.ts
@@ -1,0 +1,1 @@
+export { SalesGraph } from './SalesGraph';

--- a/src/constant/common.constant.ts
+++ b/src/constant/common.constant.ts
@@ -23,3 +23,8 @@ export const Z_INDEX = 1201;
  */
 export const GALLERY_IMAGE_XS = 140;
 export const GALLERY_IMAGE_SM = 200;
+
+/**
+ * Salesgraph Height
+ */
+export const SALESGRAPH_HEIGHT = 420;

--- a/src/data/SalesGraph/SalesGraph.ts
+++ b/src/data/SalesGraph/SalesGraph.ts
@@ -5,11 +5,11 @@ import { SalesGraphData } from './SalesGraph.type';
  * Each entry represents sales amount on a given date.
  */
 export const salesGraphData: SalesGraphData[] = [
-    { date: '01 Aug', amount: 80 },
-    { date: '02 Aug', amount: 100 },
-    { date: '03 Aug', amount: 90 },
-    { date: '04 Aug', amount: 70 },
-    { date: '05 Aug', amount: 100 },
-    { date: '06 Aug', amount: 90 },
-    { date: '07 Aug', amount: 120 },
+    { date: '01 Aug, 2025', amount: 80 },
+    { date: '02 Aug, 2025', amount: 100 },
+    { date: '03 Aug, 2025', amount: 90 },
+    { date: '04 Aug, 2025', amount: 70 },
+    { date: '05 Aug, 2025', amount: 100 },
+    { date: '06 Aug, 2025', amount: 90 },
+    { date: '07 Aug, 2025', amount: 120 },
 ];

--- a/src/data/SalesGraph/SalesGraph.ts
+++ b/src/data/SalesGraph/SalesGraph.ts
@@ -2,10 +2,7 @@ import { SalesGraphData } from './SalesGraph.type';
 
 /**
  * Sample data for the sales graph.
- *
  * Each entry represents sales amount on a given date.
- *
- * @type {SalesGraphData[]}
  */
 export const salesGraphData: SalesGraphData[] = [
     { date: '01 Aug', amount: 80 },

--- a/src/data/SalesGraph/SalesGraph.ts
+++ b/src/data/SalesGraph/SalesGraph.ts
@@ -8,11 +8,11 @@ import { SalesGraphData } from './SalesGraph.type';
  * @type {SalesGraphData[]}
  */
 export const salesGraphData: SalesGraphData[] = [
-    { date: '01 Apr', amount: 80 },
-    { date: '02 Apr', amount: 100 },
-    { date: '03 Apr', amount: 90 },
-    { date: '04 Apr', amount: 70 },
-    { date: '05 Apr', amount: 100 },
-    { date: '06 Apr', amount: 90 },
-    { date: '07 Apr', amount: 120 },
+    { date: '01 Aug', amount: 80 },
+    { date: '02 Aug', amount: 100 },
+    { date: '03 Aug', amount: 90 },
+    { date: '04 Aug', amount: 70 },
+    { date: '05 Aug', amount: 100 },
+    { date: '06 Aug', amount: 90 },
+    { date: '07 Aug', amount: 120 },
 ];

--- a/src/data/SalesGraph/SalesGraph.ts
+++ b/src/data/SalesGraph/SalesGraph.ts
@@ -5,11 +5,11 @@ import { SalesGraphData } from './SalesGraph.type';
  * Each entry represents sales amount on a given date.
  */
 export const salesGraphData: SalesGraphData[] = [
-    { date: '01 Aug, 2025', amount: 80 },
-    { date: '02 Aug, 2025', amount: 100 },
-    { date: '03 Aug, 2025', amount: 90 },
-    { date: '04 Aug, 2025', amount: 70 },
-    { date: '05 Aug, 2025', amount: 100 },
-    { date: '06 Aug, 2025', amount: 90 },
-    { date: '07 Aug, 2025', amount: 120 },
+    { date: '2025-08-01', amount: 80 },
+    { date: '2025-08-02', amount: 100 },
+    { date: '2025-08-03', amount: 90 },
+    { date: '2025-08-04', amount: 70 },
+    { date: '2025-08-05', amount: 100 },
+    { date: '2025-08-06', amount: 90 },
+    { date: '2025-08-07', amount: 120 },
 ];

--- a/src/data/SalesGraph/SalesGraph.ts
+++ b/src/data/SalesGraph/SalesGraph.ts
@@ -1,0 +1,18 @@
+import { SalesGraphData } from './SalesGraph.type';
+
+/**
+ * Sample data for the sales graph.
+ *
+ * Each entry represents sales amount on a given date.
+ *
+ * @type {SalesGraphData[]}
+ */
+export const salesGraphData: SalesGraphData[] = [
+    { date: '01 Apr', amount: 80 },
+    { date: '02 Apr', amount: 100 },
+    { date: '03 Apr', amount: 90 },
+    { date: '04 Apr', amount: 70 },
+    { date: '05 Apr', amount: 100 },
+    { date: '06 Apr', amount: 90 },
+    { date: '07 Apr', amount: 120 },
+];

--- a/src/data/SalesGraph/SalesGraph.type.ts
+++ b/src/data/SalesGraph/SalesGraph.type.ts
@@ -1,9 +1,5 @@
 /**
  * Represents a single data point for the sales graph.
- *
- * @typedef {Object} SalesGraphData
- * @property {string} date - The date associated with the sales amount (formatted as DD-MM).
- * @property {number} amount - The sales amount for the given date.
  */
 export type SalesGraphData = {
     date: string;

--- a/src/data/SalesGraph/SalesGraph.type.ts
+++ b/src/data/SalesGraph/SalesGraph.type.ts
@@ -1,5 +1,6 @@
 /**
  * Represents a single data point for the sales graph.
+ * - date: ISO-like string.
  */
 export type SalesGraphData = {
     date: string;

--- a/src/data/SalesGraph/SalesGraph.type.ts
+++ b/src/data/SalesGraph/SalesGraph.type.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents a single data point for the sales graph.
+ *
+ * @typedef {Object} SalesGraphData
+ * @property {string} date - The date associated with the sales amount (formatted as DD-MM).
+ * @property {number} amount - The sales amount for the given date.
+ */
+export type SalesGraphData = {
+    date: string;
+    amount: number;
+};

--- a/src/layouts/MainLayout/MainLayout.styles.ts
+++ b/src/layouts/MainLayout/MainLayout.styles.ts
@@ -12,14 +12,23 @@ export const AppContainer = styled(Box)(({ theme }) => {
 });
 
 export const MainContent = styled(Box)(({ theme }) => {
-    const { mixins, spacing } = theme;
+    const { mixins, spacing, palette } = theme;
     return {
         ...mixins.flex('flex-start', 'flex-start', 'column'),
         padding: spacing(3),
         height: '100%',
         overflowY: 'auto',
-        scrollbarWidth: 'none',
         width: '100%',
+        scrollbarWidth: 'thin',
+        scrollbarColor: `${palette.grey[400]} ${palette.grey[100]}`,
+        '&::-webkit-scrollbar': { width: spacing(1) },
+        '&::-webkit-scrollbar-thumb': {
+            backgroundColor: palette.grey[400],
+            borderRadius: spacing(1),
+        },
+        '&::-webkit-scrollbar-track': {
+            backgroundColor: palette.grey[100],
+        },
     };
 });
 

--- a/src/layouts/MainLayout/MainLayout.styles.ts
+++ b/src/layouts/MainLayout/MainLayout.styles.ts
@@ -18,6 +18,7 @@ export const MainContent = styled(Box)(({ theme }) => {
         padding: spacing(3),
         height: '100%',
         overflowY: 'auto',
+        scrollbarWidth: 'none',
         width: '100%',
     };
 });

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { SalesGraph } from '@components/SalesGraph';
 import { ImageGridContainer } from '@container/ImageGrid/ImageGrid.container';
 
 export const Dashboard = () => (
-    <Box display="flex" flexDirection="column" gap="12">
+    <Box display="flex" flexDirection="column" gap={3}>
         <ImageGridContainer data={itemData} />
         <SalesGraph />
     </Box>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,13 @@
 import { itemData } from 'data/ImageGrid/ImageGrid';
 
-import { ImageGridContainer } from '@container/ImageGrid';
+import { Box } from '@mui/material';
 
-export const Dashboard = () => <ImageGridContainer data={itemData} />;
+import { SalesGraph } from '@components/SalesGraph';
+import { ImageGridContainer } from '@container/ImageGrid/ImageGrid.container';
+
+export const Dashboard = () => (
+    <Box display="flex" flexDirection="column" gap="12">
+        <ImageGridContainer data={itemData} />
+        <SalesGraph />
+    </Box>
+);

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { itemData } from 'data/ImageGrid/ImageGrid';
+import { salesGraphData } from 'data/SalesGraph/SalesGraph';
 
 import { Box } from '@mui/material';
 
@@ -8,6 +9,6 @@ import { ImageGridContainer } from '@container/ImageGrid/ImageGrid.container';
 export const Dashboard = () => (
     <Box display="flex" flexDirection="column" gap={3}>
         <ImageGridContainer data={itemData} />
-        <SalesGraph />
+        <SalesGraph data={salesGraphData} />
     </Box>
 );

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -6,6 +6,8 @@ import type {
 
 import { HTML_FONT_SIZE } from '@constant/index';
 
+import { theme } from '..';
+
 /* Custom px to rem function */
 const typographyUtil: TypographyUtils = {
     pxToRem: (px: number) => `${px / HTML_FONT_SIZE}rem`,
@@ -84,6 +86,11 @@ const typographyStyle = ({
         fontWeight: 600,
         lineHeight: 1.5,
         color: palette.grey[500],
+
+        [theme.breakpoints.down('sm')]: {
+            fontSize: pxToRem(12),
+            fontWeight: 400,
+        },
     },
 
     caption: {

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -5,8 +5,7 @@ import type {
 } from '@mui/material/styles/createTypography';
 
 import { HTML_FONT_SIZE } from '@constant/index';
-
-import { theme } from '..';
+import { theme } from '@theme/index';
 
 /* Custom px to rem function */
 const typographyUtil: TypographyUtils = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz"
   integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.28.0":
+"@babel/core@^7.28.0":
   version "7.28.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz"
   integrity sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==
@@ -199,7 +199,7 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@*", "@emotion/cache@^11.13.5", "@emotion/cache@^11.14.0":
+"@emotion/cache@^11.13.5", "@emotion/cache@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz"
   integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
@@ -227,7 +227,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0", "@emotion/react@^11.4.1", "@emotion/react@^11.5.0":
+"@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -241,7 +241,7 @@
     "@emotion/weak-memoize" "^0.4.0"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@*", "@emotion/serialize@^1.3.3":
+"@emotion/serialize@^1.3.3":
   version "1.3.3"
   resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz"
   integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
@@ -257,7 +257,7 @@
   resolved "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz"
   integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
-"@emotion/styled@^11.14.0", "@emotion/styled@^11.3.0":
+"@emotion/styled@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz"
   integrity sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==
@@ -279,7 +279,7 @@
   resolved "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz"
   integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
 
-"@emotion/utils@*", "@emotion/utils@^1.4.2":
+"@emotion/utils@^1.4.2":
   version "1.4.2"
   resolved "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz"
   integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
@@ -294,15 +294,15 @@
   resolved "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz"
   integrity sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==
 
-"@esbuild/android-arm@0.24.2":
-  version "0.24.2"
-  resolved "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz"
-  integrity sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==
-
 "@esbuild/android-arm64@0.24.2":
   version "0.24.2"
   resolved "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz"
   integrity sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==
+
+"@esbuild/android-arm@0.24.2":
+  version "0.24.2"
+  resolved "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz"
+  integrity sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==
 
 "@esbuild/android-x64@0.24.2":
   version "0.24.2"
@@ -329,15 +329,15 @@
   resolved "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz"
   integrity sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==
 
-"@esbuild/linux-arm@0.24.2":
-  version "0.24.2"
-  resolved "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz"
-  integrity sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==
-
 "@esbuild/linux-arm64@0.24.2":
   version "0.24.2"
   resolved "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz"
   integrity sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==
+
+"@esbuild/linux-arm@0.24.2":
+  version "0.24.2"
+  resolved "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz"
+  integrity sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==
 
 "@esbuild/linux-ia32@0.24.2":
   version "0.24.2"
@@ -527,15 +527,15 @@
   resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz"
   integrity sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==
 
-"@img/sharp-libvips-linux-arm@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz"
-  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
-
 "@img/sharp-libvips-linux-arm64@1.0.4":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz"
   integrity sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==
+
+"@img/sharp-libvips-linux-arm@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz"
+  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
 
 "@img/sharp-libvips-linux-s390x@1.0.4":
   version "1.0.4"
@@ -557,19 +557,19 @@
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz"
   integrity sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==
 
-"@img/sharp-linux-arm@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz"
-  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.0.5"
-
 "@img/sharp-linux-arm64@0.33.5":
   version "0.33.5"
   resolved "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz"
   integrity sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==
   optionalDependencies:
     "@img/sharp-libvips-linux-arm64" "1.0.4"
+
+"@img/sharp-linux-arm@0.33.5":
+  version "0.33.5"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz"
+  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.0.5"
 
 "@img/sharp-linux-s390x@0.33.5":
   version "0.33.5"
@@ -662,7 +662,7 @@
   dependencies:
     "@babel/runtime" "^7.26.0"
 
-"@mui/material@^5.0.0 || ^6.0.0 || ^7.0.0", "@mui/material@^6.4.1":
+"@mui/material@^6.4.1":
   version "6.4.1"
   resolved "https://registry.npmjs.org/@mui/material/-/material-6.4.1.tgz"
   integrity sha512-MFBfia6UiKxyoLeGkAh8M15bkeDmfnsUTMRJd/vTQue6YQ8AQ6lw9HqDthyYghzDEWIvZO/lQQzLrZE8XwNJLA==
@@ -740,7 +740,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -757,6 +757,18 @@
   version "2.11.8"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@reduxjs/toolkit@1.x.x || 2.x.x":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.8.2.tgz#f4e9f973c6fc930c1e0f3bf462cc95210c28f5f9"
+  integrity sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@standard-schema/utils" "^0.3.0"
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
 
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
@@ -858,6 +870,16 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz"
   integrity sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==
 
+"@standard-schema/spec@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"
@@ -891,6 +913,57 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/d3-array@^3.0.3":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.1.tgz#1f6658e3d2006c4fceac53fde464166859f8b8c5"
+  integrity sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-ease@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-interpolate@^3.0.1":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-shape@^3.1.0":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.7.tgz#2b7b423dc2dfe69c8c93596e673e37443348c555"
+  integrity sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
 "@types/eslint-plugin-jsx-a11y@6":
   version "6.10.0"
   resolved "https://registry.npmjs.org/@types/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz"
@@ -906,7 +979,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.6", "@types/estree@1.0.6":
+"@types/estree@*", "@types/estree@1.0.6", "@types/estree@^1.0.6":
   version "1.0.6"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -916,7 +989,7 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@22.10.7":
+"@types/node@22.10.7":
   version "22.10.7"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz"
   integrity sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==
@@ -943,12 +1016,17 @@
   resolved "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react@^19.0.0", "@types/react@^19.0.7":
+"@types/react@^19.0.7":
   version "19.0.7"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.0.7.tgz"
   integrity sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==
   dependencies:
     csstype "^3.0.2"
+
+"@types/use-sync-external-store@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
+  integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
 "@typescript-eslint/eslint-plugin@8.21.0":
   version "8.21.0"
@@ -965,7 +1043,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.0.0"
 
-"@typescript-eslint/parser@^8.0.0 || ^8.0.0-alpha.0", "@typescript-eslint/parser@8.21.0":
+"@typescript-eslint/parser@8.21.0":
   version "8.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.21.0.tgz"
   integrity sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==
@@ -1048,7 +1126,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.14.0, acorn@^8.8.2:
+acorn@^8.14.0, acorn@^8.8.2:
   version "8.14.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
@@ -1087,12 +1165,7 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
-  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
-
-ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -1241,7 +1314,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.25.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz"
   integrity sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==
@@ -1413,6 +1486,77 @@ csstype@^3.0.2, csstype@^3.1.3:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-ease@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-shape@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-timer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
@@ -1451,6 +1595,11 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@~4.4
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
+
+decimal.js-light@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1653,6 +1802,11 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
 
+es-toolkit@^1.39.3:
+  version "1.39.8"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.8.tgz#314aca3988fc1f2c3faa95b49c3029f44c690f50"
+  integrity sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==
+
 esbuild@^0.24.2:
   version "0.24.2"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz"
@@ -1777,7 +1931,7 @@ eslint-visitor-keys@^4.2.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz"
   integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
 
-"eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@>=5.0.0, eslint@>=7.0.0, eslint@>=8.40, eslint@9.18.0:
+eslint@9.18.0:
   version "9.18.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz"
   integrity sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==
@@ -2039,15 +2193,15 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-globals@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
-  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
-
 globals@15.14.0:
   version "15.14.0"
   resolved "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz"
   integrity sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==
+
+globals@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
+  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -2137,6 +2291,11 @@ ignore@^5.2.0, ignore@^5.3.1:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
+immer@^10.0.3, immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
@@ -2158,6 +2317,11 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
@@ -2822,7 +2986,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-"react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@>=16.6.0, react-dom@>=18, react-dom@19.0.0:
+react-dom@19.0.0:
   version "19.0.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz"
   integrity sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==
@@ -2836,12 +3000,7 @@ react-error-boundary@^6.0.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -2850,6 +3009,14 @@ react-is@^19.0.0:
   version "19.0.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz"
   integrity sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==
+
+"react-redux@8.x.x || 9.x.x":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
+  integrity sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==
+  dependencies:
+    "@types/use-sync-external-store" "^0.0.6"
+    use-sync-external-store "^1.4.0"
 
 react-refresh@^0.17.0:
   version "0.17.0"
@@ -2881,10 +3048,37 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^17.0.0 || ^18.0.0 || ^19.0.0", react@^19.0.0, react@>=16.13.1, react@>=16.6.0, react@>=16.8.0, react@>=18, react@19.0.0:
+react@19.0.0:
   version "19.0.0"
   resolved "https://registry.npmjs.org/react/-/react-19.0.0.tgz"
   integrity sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==
+
+recharts@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-3.1.2.tgz#44626509c6567ed8208d3347e915397d480bb3d2"
+  integrity sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==
+  dependencies:
+    "@reduxjs/toolkit" "1.x.x || 2.x.x"
+    clsx "^2.1.1"
+    decimal.js-light "^2.5.1"
+    es-toolkit "^1.39.3"
+    eventemitter3 "^5.0.1"
+    immer "^10.1.1"
+    react-redux "8.x.x || 9.x.x"
+    reselect "5.1.1"
+    tiny-invariant "^1.3.3"
+    use-sync-external-store "^1.2.2"
+    victory-vendor "^37.0.2"
+
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
+
+redux@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
+  integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -2916,6 +3110,11 @@ regexp.prototype.flags@^1.5.3:
     get-proto "^1.0.1"
     gopd "^1.2.0"
     set-function-name "^2.0.2"
+
+reselect@5.1.1, reselect@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3031,12 +3230,7 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.6.0:
-  version "7.6.3"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-semver@^7.6.3:
+semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -3325,7 +3519,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-terser@^5.16.0, terser@5.37.0:
+terser@5.37.0:
   version "5.37.0"
   resolved "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz"
   integrity sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==
@@ -3334,6 +3528,11 @@ terser@^5.16.0, terser@5.37.0:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
+
+tiny-invariant@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -3356,15 +3555,6 @@ tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tss-react@^4.9.19:
-  version "4.9.19"
-  resolved "https://registry.npmjs.org/tss-react/-/tss-react-4.9.19.tgz"
-  integrity sha512-mmeec1wmLJKUpbaEfsQIOgk0ZtaVBt/oMbiWUFzCnxNm7vb6sDEA3ez/5/ll1eg74nrOcy9BjA+qEuF7nUV0bA==
-  dependencies:
-    "@emotion/cache" "*"
-    "@emotion/serialize" "*"
-    "@emotion/utils" "*"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -3427,7 +3617,7 @@ typescript-eslint@8.21.0:
     "@typescript-eslint/parser" "8.21.0"
     "@typescript-eslint/utils" "8.21.0"
 
-typescript@^5.0.0, typescript@>=4.8.4, "typescript@>=4.8.4 <5.8.0", typescript@5.7.3:
+typescript@5.7.3:
   version "5.7.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
@@ -3462,6 +3652,31 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
+  integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+
+victory-vendor@^37.0.2:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-37.3.6.tgz#401ac4b029a0b3d33e0cba8e8a1d765c487254da"
+  integrity sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==
+  dependencies:
+    "@types/d3-array" "^3.0.3"
+    "@types/d3-ease" "^3.0.0"
+    "@types/d3-interpolate" "^3.0.1"
+    "@types/d3-scale" "^4.0.2"
+    "@types/d3-shape" "^3.1.0"
+    "@types/d3-time" "^3.0.0"
+    "@types/d3-timer" "^3.0.0"
+    d3-array "^3.1.6"
+    d3-ease "^3.0.1"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.1.0"
+    d3-time "^3.0.0"
+    d3-timer "^3.0.1"
+
 vite-plugin-image-optimizer@1.1.8:
   version "1.1.8"
   resolved "https://registry.npmjs.org/vite-plugin-image-optimizer/-/vite-plugin-image-optimizer-1.1.8.tgz"
@@ -3479,7 +3694,7 @@ vite-tsconfig-paths@5.1.4:
     globrex "^0.1.2"
     tsconfck "^3.0.3"
 
-vite@*, "vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", vite@>=3, vite@6.0.11:
+vite@6.0.11:
   version "6.0.11"
   resolved "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz"
   integrity sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==
@@ -3572,11 +3787,6 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.4.2:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz"
-  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
 yaml@~2.6.1:
   version "2.6.1"


### PR DESCRIPTION
#### Description:
Output:
Large screens:
<img width="1580" height="859" alt="image" src="https://github.com/user-attachments/assets/0d61c822-193e-4f37-8c96-af36baf6fbed" />

Small screens:
<img width="266" height="382" alt="image" src="https://github.com/user-attachments/assets/d0aa260f-3649-44ef-bfb0-146b7afd021c" />


Figma design:
Large screens:
<img width="1088" height="504" alt="image" src="https://github.com/user-attachments/assets/561a694e-dc55-45b4-9f9a-0ffa0377ac8c" />

Small screens:
<img width="284" height="417" alt="image" src="https://github.com/user-attachments/assets/e16ac4d2-a03c-44a9-aa86-b65d360d297b" />



- Add tasks done in this is Pull Request

#### Development Checklist

- [ ] Documentation added at appropriate places
- [ ] UI & Responsiveness verified if needed
- [ ] Tested Cross-browser / Cross-platform
- [X] Self review complete
- [ ] Build script is running with no issues
- [ X] Lint issues resolved
- [ X] Files Formatted as per preferred formatter

#### Review Checklist

- [ ] Checked edge cases
- [ ] Reviewed code and documentation
- [ ] Verified best practices

#### Screenshots (if applicable)

Add screenshots if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a responsive Sales graph to the Dashboard with formatted axes, fixed Y ticks, custom tooltip, sample sales data, and exposed SalesGraph component.

- **Style**
  - Polished styling for the Sales graph and tooltip with responsive tweaks for small screens; updated subtitle typography for small viewports; refined scrollbar appearance in main content.

- **Chores**
  - Added Recharts as a runtime dependency; introduced related constants and type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->